### PR TITLE
Only check servers before requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ TownshipClient.prototype.secureRequest = function (opts, cb) {
 }
 
 TownshipClient.prototype._request = function (opts, cb) {
-  assert.ok(opts.server, 'Server required to send a request')
+  if (!opts.server) return new Error('Server required to send a request')
   var self = this
   var login = self.getLogin(opts.server)
   if (opts.token || login.token) opts.token = opts.token || login.token

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var assert = require('assert')
 var request = require('nets')
 var Config = require('./lib/config')
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function TownshipClient (opts) {
   var self = this
   self.config = Config(opts.config)
   self.config.init()
-  var login = self.config.getLogin()
+  var login = self.getLogin()
   self.server = opts.server
     ? opts.server.indexOf('http') > -1
       ? opts.server
@@ -84,7 +84,7 @@ TownshipClient.prototype.logout = function (opts, cb) {
   var self = this
 
   var server = self._getServer(opts)
-  if (!self.getLogin(server)) return cb(new Error('Not logged in.'))
+  if (!server || !self.getLogin(server)) return cb(new Error('Not logged in.'))
 
   self.config.setLogin({server: server})
   self.config.set('currentLogin', null)
@@ -122,12 +122,12 @@ TownshipClient.prototype.updatePassword = function (opts, cb) {
 TownshipClient.prototype.getLogin = function (server) {
   var self = this
   server = self._getServer({server: server})
+  if (!server) return null
   return self.config.getLogin(server)
 }
 
 TownshipClient.prototype._getServer = function (opts) {
   opts = opts || {}
-  assert.ok(opts.server || this.server, 'Server must be specified to make an auth request')
   return opts.server || this.server
 }
 
@@ -148,6 +148,7 @@ TownshipClient.prototype.secureRequest = function (opts, cb) {
 }
 
 TownshipClient.prototype._request = function (opts, cb) {
+  assert.ok(opts.server, 'Server required to send a request')
   var self = this
   var login = self.getLogin(opts.server)
   if (opts.token || login.token) opts.token = opts.token || login.token


### PR DESCRIPTION
Before the server was checked before a request was made. This led to some bugs (that I can't remember but Karissa ran into). 

PR changes this so we only check server immediately before the request, giving option to set it later. Also removes assert.

Sorry had this branch open just forgot to PR! 😕 