### PR TITLE
Check to make sure body has token on response

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ TownshipClient.prototype.register = function (opts, cb) {
     }
   }, function (err, res, body) {
     if (err) return cb(err)
+    if (!body.token) return cb(new Error('No token received. Check server url.'))
     body.server = server
     body.email = opts.email
     self.config.setLogin(body)
@@ -69,6 +70,7 @@ TownshipClient.prototype.login = function (opts, cb) {
     }
   }, function (err, res, body) {
     if (err) return cb(err)
+    if (!body.token) return cb('No token received. Check server url.')
     body.server = server
     body.email = opts.email
     self.config.setLogin(body)
@@ -110,6 +112,7 @@ TownshipClient.prototype.updatePassword = function (opts, cb) {
     }
   }, function (err, res, body) {
     if (err) return cb(err)
+    if (!body.token) return cb(new Error('No token received. Check server url.'))
     body.server = server
     body.email = opts.email
     self.config.setLogin(body)

--- a/tests/index.js
+++ b/tests/index.js
@@ -147,6 +147,19 @@ test('register another user', function (t) {
   })
 })
 
+test('secure request with new info', function (t) {
+  var clientToo = TownshipClient({
+    server: address,
+    routes: {
+      register: '/fakeRegister'
+    }
+  })
+  clientToo.register({email: 'joe@hand.email', password: 'verysecret'}, function (err, res, body) {
+    t.ok(err, 'gets error')
+    t.end()
+  })
+})
+
 test.onFinish(function () {
   server.close(function () {
     fs.unlink(testConfig, function () {

--- a/tests/server.js
+++ b/tests/server.js
@@ -80,6 +80,10 @@ function createApp (config) {
     })
   })
 
+  app.on('/fakeRegister', function (req, res, ctx) {
+    app.send(res, 200, {okay: 'body', no: 'token'})
+  })
+
   app.ship = ship
 
   return app


### PR DESCRIPTION
Fixes a bug that if you received a good response and body it'd set the body in the config, even if it wasn't a token.